### PR TITLE
assert.include: Added support for needles of 'Object' type.

### DIFF
--- a/src/assertive.coffee
+++ b/src/assertive.coffee
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # eat _ off the global scope, or require it ourselves if missing
 
 global = Function('return this')()
-{contains, isEqual, isString, isNumber, isRegExp, isArray, isFunction, pluck} =
+{contains, isEqual, isString, isObject, isNumber, isRegExp, isArray, isFunction, pluck, find} =
 _ = global._ ? require 'underscore'
 
 
@@ -105,6 +105,8 @@ assert =
         contained = haystack.match needle
       else
         contained = haystack.indexOf(needle) isnt -1
+    else if isObject needle
+      contained = (find haystack, (obj) -> isEqual obj, needle)?
     else
       contained = contains haystack, needle
 


### PR DESCRIPTION
"Assert.include: Added support for needles of 'Object' type."

Hey @johan , Currently assert.include(needle, haystack) doesnot support needle of Object type. Particularly, useful for asserting presence of a 'hash' in a array of hashes.

It throws error on 
```
> assert.include
[Function]
> haystack = [{1:2},3]
[ { '1': 2 }, 3 ]
> needle = {1:2}
{ '1': 2 }
> assert.include(needle,haystack)
Error: include expected needle to be found in haystack
- needle: {"1":2}
haystack: [{"1":2},3]
    at error (node_modules/assertive/lib/assertive.js:443:12)
    at Object.assert.include (node_modules/assertive/lib/assertive.js:186:15)
    at repl:1:9
    at REPLServer.self.eval (repl.js:110:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
```

If there is any other way around. Kindly tell. Pardon my ignorance.

Otherwise, I tried to add the functionality myself. This PR is for the same. After adding this PR, assert.include checks presence of needle ( 'Object' type ) in haystack ('Array' type) as well.

```
> assert.include
[Function]
> haystack = [{1:2},3]
[ { '1': 2 }, 3 ]
> needle = {1:2}
{ '1': 2 }
> assert.include(needle,haystack)
undefined
>
```

I will add the test-cases once you agree for adding this functionality.