### PR TITLE
sane printouts of Symbols in assertion errors

### DIFF
--- a/lib/assertive.js
+++ b/lib/assertive.js
@@ -409,6 +409,8 @@ void function () {
       return 'NaN';
     if (isRegExp(x))
       return asRegExp(x);
+    if (typeof x === 'symbol')
+      return x.toString();
     json = JSON.stringify(x, function (key, val) {
       if (typeof val === 'function')
         return toString(val);

--- a/src/assertive.coffee
+++ b/src/assertive.coffee
@@ -280,6 +280,7 @@ stringify = (x) ->
   return "#{x}"  unless x?
   return 'NaN'  if _.isNaN x
   return asRegExp x  if isRegExp x
+  return x.toString()  if typeof x is 'symbol'
   json = JSON.stringify x, (key, val) ->
     return toString val  if typeof val is 'function'
     return asRegExp val  if isRegExp val


### PR DESCRIPTION
A quick fix for #13 for @jkrems.

Suggestions or PR:s to add Travis magic to invoke tests that produce Symbols would be appreciated; seems we might need to run on iojs for this one, at the moment.