### PR TITLE
Change bind for partial in order to support non ECMAScript 5 environments

### DIFF
--- a/lib/assertive.js
+++ b/lib/assertive.js
@@ -248,7 +248,7 @@ isType = function(value, typeName) {
 };
 
 getTypeName = function(value) {
-  return _.find(types, isType.bind(this, value));
+  return _.find(types, _.partial(isType, value));
 };
 
 getNameOfType = function(x) {

--- a/src/assertive.coffee
+++ b/src/assertive.coffee
@@ -227,7 +227,7 @@ isType = (value, typeName) ->
 
 # gets the name of the type that value is an incarnation of
 getTypeName = (value) ->
-  _.find types, isType.bind this, value
+  _.find types, _.partial isType, value
 
 # translates any argument we were meant to interpret as a type, into its name
 getNameOfType = (x) ->


### PR DESCRIPTION
**Issue**:
While using `assertive` with `PhantomJS 1.9.X`,  I was getting the following errors:
```
message: >
    'undefined' is not a function (evaluating 'isType.bind(this, value)')
stack: >
    TypeError: 'undefined' is not a function (evaluating 'isType.bind(this, value)')
        at http://localhost:7357/node_modules/assertive/lib/assertive.js:324
        at http://localhost:7357/node_modules/assertive/lib/assertive.js:274
        at http://localhost:7357/test/tmp/client/deal_builder/frontend/campaignApi.js:17
```

**Cause**:
`PhantomJS 1.9.X` doesn't support `ECMAScript 5`, therefore doesn't support `bind`, causing the failure.

**Solution**:
Replace `bind` for [`_.partial`](https://lodash.com/docs#partial)

**Notes**:
I wasn't sure what kind of test to add for this kind of fix, any recommendations?