### PR TITLE
feat: integrate assertive-as-promised functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ able to glean what you need immediately.
 
 It also tries to pre-empt false negative tests from ever happening, by
 rigorously testing for correct assertion invocation and by avoiding to
-pick names for assertions with a treck record of being misinterpreted,
+pick names for assertions with a track record of being misinterpreted,
 not just by people reading the code, but also by programmers _writing_
 them, which can make even 100%-test-coverage code fail on behalf of it
 testing for the wrong thing.
@@ -61,6 +61,12 @@ Actually: 10
 There have been test suites full of no-op tests similar to this, which
 have gone undetected for months or years, giving a false sense of what
 regressions you are guarded against.
+
+You may pass any of the functions an item to be tested as a promise,
+and it will be tested after the promise is resolved.  In this case, the
+test will return a promise which will be resolved or rejected as appropriate.
+A promise-aware test runner (e.g. [Mocha](https://mochajs.org/)
+version >= 1.18.0) is highly recommended.
 
 These docs show a typical invocation, and what you see when it failed:
 
@@ -174,10 +180,33 @@ assert.hasType(undefined, value)
 # same test for a more specific type (listed above) was true
 ```
 
+### `resolves`
+```
+promise = assert.resolves(promise)
+promise = assert.resolves(explanation, promise)
+# Wait for promise to resolve, then resolve if successful, reject otherwise
+# Always returns a promise, unless called with non-promise (not allowed)
+
+Assertion failed: should resolve to good stuff
+Promise was rejected despite resolves assertion:
+Timeout in 10000ms
+```
+
+### `rejects`
+```
+promiseForErr = assert.rejects(promise)
+promiseForErr = assert.rejects(explanation, promise)
+# Wait for promise to reject, resolve with error if it does, reject otherwise
+# Basically inverse of resolves(), but resolves with the error for more testing
+# Always returns a promise, unless called with non-promise (not allowed)
+
+Assertion failed: should reject after Timeout
+Promise wasn't rejected as expected to
+```
+
 ### `falsey`, `notEqual`, `notDeepEqual`, `notInclude`, `notMatch`, `notThrows`, `notHasType`
 Versions of the above functions taking the same arguments, but asserting
 the opposite outcome. The assertion failure messages are just as helpful.
-
 
 License
 ----------------------------------------------------------------------

--- a/lib/assertive.js
+++ b/lib/assertive.js
@@ -31,14 +31,16 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var _, abbreviate, asRegExp, assert, clear, error, getNameOfType, getTypeName, global, green, handleArgs, i, implodeNicely, includes, isArray, isEqual, isFunction, isNumber, isRegExp, isString, isType, len, map, name, nameNegative, positiveAssertions, red, ref, ref1, ref2, stringify, toString, type, types,
-  indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+var _, abbreviate, asRegExp, assert, assertSync, clear, error, fn, fn1, getNameOfType, getTypeName, global, green, handleArgs, i, implodeNicely, includes, isArray, isEqual, isFunction, isNumber, isPromiseAlike, isRegExp, isString, isType, len, map, name, nameNegative, positiveAssertions, red, ref, ref1, ref2, stringify, toString, type, types,
+  indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
+  slice = [].slice,
+  hasProp = {}.hasOwnProperty;
 
 global = Function('return this')();
 
 ref1 = _ = (ref = global._) != null ? ref : require('lodash'), includes = ref1.includes, isEqual = ref1.isEqual, isString = ref1.isString, isNumber = ref1.isNumber, isRegExp = ref1.isRegExp, isArray = ref1.isArray, isFunction = ref1.isFunction, map = ref1.map;
 
-assert = {
+assertSync = {
   truthy: function(bool) {
     var explanation, name, negated, ref2;
     ref2 = handleArgs(this, [1, 2], arguments, 'truthy'), name = ref2[0], negated = ref2[1];
@@ -55,9 +57,9 @@ assert = {
       explanation = arguments[0], bool = arguments[1];
     }
     if (explanation) {
-      return assert.equal(explanation, true, bool);
+      return assertSync.equal(explanation, true, bool);
     } else {
-      return assert.equal(true, bool);
+      return assertSync.equal(true, bool);
     }
   },
   equal: function(expected, actual) {
@@ -223,6 +225,9 @@ nameNegative = function(name) {
   if (name === 'truthy') {
     return 'falsey';
   }
+  if (name === 'resolves') {
+    return 'rejects';
+  }
   return 'not' + name.charAt().toUpperCase() + name.slice(1);
 };
 
@@ -230,11 +235,62 @@ positiveAssertions = ['truthy', 'equal', 'deepEqual', 'include', 'match', 'throw
 
 for (i = 0, len = positiveAssertions.length; i < len; i++) {
   name = positiveAssertions[i];
-  assert[nameNegative(name)] = (function(name) {
+  assertSync[nameNegative(name)] = (function(name) {
     return function() {
-      return assert[name].apply('!', arguments);
+      return assertSync[name].apply('!', arguments);
     };
   })(name);
+}
+
+assert = {
+  resolves: function(testee) {
+    var explanation, negated, ref2;
+    ref2 = handleArgs(this, [1, 2], arguments, 'resolves'), name = ref2[0], negated = ref2[1];
+    if (arguments.length === 2) {
+      explanation = arguments[0], testee = arguments[1];
+    }
+    if (!isPromiseAlike(testee)) {
+      throw error(name + " expects " + (green('a promise')) + " but got " + (red(stringify(testee))));
+    }
+    if (name === 'rejects') {
+      return testee.then((function() {
+        throw error("Promise wasn't rejected as expected to", explanation);
+      }), function(err) {
+        return err;
+      });
+    } else {
+      return testee["catch"](function(err) {
+        var ref3;
+        throw error("Promise was rejected despite resolves assertion:\n" + ((ref3 = err != null ? err.message : void 0) != null ? ref3 : err), explanation);
+      });
+    }
+  },
+  rejects: function(testee) {
+    return assert.resolves.apply('!', arguments);
+  }
+};
+
+fn1 = function(name, fn) {
+  return assert[name] = function() {
+    var args, testee;
+    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    if (!args.length) {
+      return fn();
+    }
+    testee = args.pop();
+    if (isPromiseAlike(testee)) {
+      return testee.then(function(val) {
+        return fn.apply(null, slice.call(args).concat([val]));
+      });
+    } else {
+      return fn.apply(null, slice.call(args).concat([testee]));
+    }
+  };
+};
+for (name in assertSync) {
+  if (!hasProp.call(assertSync, name)) continue;
+  fn = assertSync[name];
+  fn1(name, fn);
 }
 
 types = ['null', 'Date', 'Array', 'String', 'RegExp', 'Boolean', 'Function', 'Object', 'NaN', 'Number', 'undefined'];
@@ -435,6 +491,10 @@ handleArgs = function(self, count, args, name, help) {
     help = help();
   }
   throw error(message, help);
+};
+
+isPromiseAlike = function(p) {
+  return p === Object(p) && 'function' === typeof p.then;
 };
 
 if (((typeof module !== "undefined" && module !== null ? module.exports : void 0) != null)) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "assertive": "^2.0.0",
+    "bluebird": "^3.3.4",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.10.1",
     "coffeelint-use-strict": "0.0.1",
@@ -43,10 +43,12 @@
     "nodemon": "^1.0.0"
   },
   "author": {
-    "name": "Johan Sundström",
-    "email": "jsundstrom@groupon.com"
+    "name": "Groupon",
+    "email": "opensource@groupon.com"
   },
   "contributors": [
+    "David Bushong <dbushong@groupon.com>",
+    "Johan Sundström <jsundstrom@groupon.com>",
     "Sean Massa <smassa@groupon.com>"
   ],
   "files": [

--- a/test/assertive.test.coffee
+++ b/test/assertive.test.coffee
@@ -1,5 +1,7 @@
 'use strict'
 
+Promise = require 'bluebird'
+
 { truthy,    falsey
 , expect,    notExpect
 , equal,     notEqual
@@ -8,6 +10,7 @@
 , match,     notMatch
 , throws,    notThrows
 , hasType,   notHasType
+, resolves,  rejects
 } = require '../lib/assertive'
 
 describe 'throws', ->
@@ -634,3 +637,25 @@ describe 'notHasType', ->
   it 'recognizes not-undefined', ->
     notHasType undefined, null
     throws -> notHasType undefined, undefined
+
+describe 'rejects', ->
+  it 'errors synchronously on non-promise', ->
+    match /^rejects expects/, throws(-> rejects 42).message
+
+  it 'resolves for a rejected promise', ->
+    equal 'kittens', rejects Promise.reject 'kittens'
+
+  it 'rejects a resolved promise', ->
+    equal "Promise wasn't rejected as expected to",
+      rejects(rejects Promise.resolve 42).get('message')
+
+describe 'resolves', ->
+  it 'errors synchronously on non-promise', ->
+    match /^resolves expects/, throws(-> resolves {}).message
+
+  it 'rejects for a rejected promise', ->
+    include 'Promise was rejected despite resolves assertion:\n42',
+      rejects(resolves Promise.reject new Error 42).get('message')
+
+  it 'resolves for a resolved promise', ->
+    equal 'kittens', resolves Promise.resolve 'kittens'

--- a/test/promisified.test.coffee
+++ b/test/promisified.test.coffee
@@ -1,0 +1,96 @@
+# test the auto-promise-awarified versions of common tests
+
+Promise = require 'bluebird'
+assert  = require '../lib/assertive'
+
+syncFuncs =
+  truthy:
+    pass:
+      args: [true], descr: 'a truthy promise resolution'
+    fail:
+      args: [false]
+      descr: 'a falsey promise resolution'
+      explain: 'resolves to true'
+
+  equal:
+    pass: args: [5, 5], descr: 'an equal promise resolution'
+    fail:
+      args: [5, 6]
+      descr: 'an inequal promise resolution'
+      explain: '5 is 5'
+
+  deepEqual:
+    pass:
+      args: [['a', 'b'], ['a', 'b']]
+      descr: 'a deep equal promise resolution'
+    fail:
+      args: [['a', 'b'], 'x']
+      descr: 'a deep inequal promise resolution'
+      explain: 'a,b is a,b'
+
+  include:
+    pass:
+      args: ['x', 'fox']
+      descr: 'needle inclusion in haystack promise resolution'
+    fail:
+      args: ['x', 'dog']
+      descr: 'needle exclusion from haystack promise resolution'
+      explain: 'x in word'
+
+  match:
+    pass: args: [/x/, 'fox'], descr: 'match /x/'
+    fail:
+      args: [/x/, 'dog']
+      descr: 'needle exclusion from haystack promise resolution'
+      explain: '/x/ matches word'
+
+  throws:
+    pass:
+      args: [-> throw 'foo']
+      descr: 'a promise for an excepting function'
+    fail:
+      args: [ -> 'foo' ]
+      descr: 'a promise for a non-excepting function'
+      explain: 'function throws an exception'
+
+  notThrows:
+    pass:
+      args: [-> 42]
+      descr: 'a non-excepting function'
+    fail:
+      args: [ -> throw 'foo' ]
+      descr: 'a promise for an excepting function'
+      explain: 'function does not throw an exception'
+
+  hasType:
+    pass:
+      args: [Boolean, true]
+      descr: 'matched type on promise resolution'
+    fail:
+      args: [Boolean, 'true']
+      descr: 'mismatched type on promise resolution'
+      explain: 'result is a boolean'
+
+describe 'promise-aware functionality', ->
+  for name, bits of syncFuncs
+    do (name, bits) ->
+      {pass, fail} = bits
+      for pf, {args} of bits
+        # replace last argument with promised resolution of same
+        bits[pf].pargs = args[0...args.length-1].concat(
+          [Promise.resolve(args[args.length-1])])
+
+      describe name, ->
+        it 'returns a promise when passed a promise', ->
+          assert.expect assert[name](pass.pargs...) instanceof Promise
+
+        it 'does not return a promise when not passed one', ->
+          assert.expect not (assert[name](pass.args...) instanceof Promise)
+
+        it "resolves for #{pass.descr}", ->
+          assert.resolves "#{name} should succeed", assert[name] pass.pargs...
+
+        it "rejects for #{fail.descr}", ->
+          assert.rejects "#{name} should throw",
+            assert[name] fail.explain, fail.pargs...
+          .then (err) -> assert.include fail.explain, err.message


### PR DESCRIPTION
* existing functions now all accept promise instead of testee argument
* no promise library required beyond what is used to create testee promises
* `rejects` and `resolves` functions added for promise-specific behavior
* promisification tests added
* docs added
* See https://github.com/groupon/assertive-as-promised for background