### PR TITLE
feat: show object diffs in deepEqual errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,19 @@ assert.equal(explanation, expected, actual);
 assert.deepEqual(expected, actual);
 assert.deepEqual(explanation, expected, actual);
 
-// Assertion failed: ensure that all methods we tested were handled, and in the right order
-// mismatch: {"methods":["GET"]} didn't
-// deepEqual {"methods":["GET","POST","PUT","DELETE"]}
+/*
+Assertion failed: ensure that all methods we tested were handled, and in the right order
+Actual: - Expected: +
+  {
+    "methods": [
+      "GET",
+-     "GET",
++     "POST",
++     "PUT",
++     "DELETE"
+    ]
+  }
+*/
 ```
 
 ### `include`

--- a/lib/assertive.js
+++ b/lib/assertive.js
@@ -40,6 +40,11 @@ let assert;
 // eslint-disable-next-line global-require
 const _ = global._ || require('lodash');
 
+// we can make this optional for browser use
+let jsDiff;
+// eslint-disable-next-line global-require
+try { jsDiff = require('diff'); } catch (err) { /* */ }
+
 const toString = Object.prototype.toString;
 
 let green = x => `\x1B[32m${x}\x1B[39m`;
@@ -265,24 +270,38 @@ const assertSync = {
       actual = arguments[2];
     }
     const isEqual = _.isEqual(expected, actual);
-    if ((!isEqual && !negated) || (isEqual && negated)) {
-      const wrongLooks = stringify(actual);
-      if (negated) {
-        throw error(`notDeepEqual assertion expected exactly anything else but
-${red(wrongLooks)}`, explanation);
-      }
+    if ((isEqual && !negated) || (!isEqual && negated)) return;
 
-      const rightLooks = stringify(expected);
-      let message;
-      if (wrongLooks === rightLooks) {
-        message = `deepEqual ${green(rightLooks)} failed on something that\n` +
-          'serializes to the same result (likely some function)';
-      } else {
-        message = `Expected: ${green(rightLooks)}\n Actually: ` +
-          `${red(wrongLooks)}`;
-      }
-      throw error(message, explanation);
+    const wrongLooks = stringify(actual);
+    if (negated) {
+      throw error(`notDeepEqual assertion expected exactly anything else but
+${red(wrongLooks)}`, explanation);
     }
+
+    const rightLooks = stringify(expected);
+    let message;
+    if (wrongLooks === rightLooks) {
+      message = `deepEqual ${green(rightLooks)} failed on something that\n` +
+        'serializes to the same result (likely some function)';
+    } else if (jsDiff) {
+      const values = jsDiff.diffJson(actual, expected).map((entry) => {
+        let value = entry.value;
+        let prefix = '  ';
+        if (entry.added) prefix = '+ ';
+        else if (entry.removed) prefix = '- ';
+        value = value.replace(/^/gm, prefix).replace(/\n..$/, '');
+        if (entry.added) value = green(value);
+        else if (entry.removed) value = red(value);
+        return value;
+      });
+      message =
+        `Actual: ${red('-')} Expected: ${green('+')}\n${values.join('\n')}`;
+    } else {
+      message = `Expected: ${green(rightLooks)}\n Actually: ` +
+        `${red(wrongLooks)}`;
+    }
+
+    throw error(message, explanation);
   },
 
   include(needle, haystack) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   },
   "dependencies": {
+    "diff": "^3.3.0",
     "lodash": "^4.6.1"
   },
   "devDependencies": {

--- a/test/assertive.test.js
+++ b/test/assertive.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const assert = require('assertive');
+const assert = require('../');
 
 // c'mon node6
 const truthy = assert.truthy;
@@ -47,7 +47,7 @@ describe('throws', () => {
     equal(throws(() => { throw 'we suck'; }), 'we suck');
   });
 
-  return it('includes your helpful explanation, when provided', () => {
+  it('includes your helpful explanation, when provided', () => {
     const explanation = 'No error was thrown - this is a problem';
     const err = throws(() => throws(explanation, () => {}));
     include(explanation, err.message);
@@ -79,7 +79,7 @@ describe('notThrows', () => {
     include('assertion:\n68040', caught.message);
   });
 
-  return it('includes your helpful explanation, when provided', () => {
+  it('includes your helpful explanation, when provided', () => {
     const explanation = 'No error was thrown - this is a problem';
     const err = throws(() => notThrows(explanation, () => { throw new Error('aiee!'); }));
     include(explanation, err.message);
@@ -262,15 +262,15 @@ describe('notEqual', () => {
     throws(function shouldThrow() { return notEqual(this, this); });
     throws(() => notEqual(null, null));
     throws(() => {
-      let x;
-      return notEqual((x = []), x);
+      const x = [];
+      return notEqual(x, x);
     });
     throws(() => notEqual(undefined, undefined));
     throws(() => notEqual(false, false));
     throws(() => notEqual(true, true));
   });
 
-  return it('includes your helpful explanation, when provided', () => {
+  it('includes your helpful explanation, when provided', () => {
     const explanation = "it doesn't get more equal than identical";
     const err = throws(() => notEqual(explanation, Math.PI, Math.PI));
     include(explanation, err.message);
@@ -318,9 +318,9 @@ describe('deepEqual', () => {
     include(explanation, err.message);
   });
 
-  return it('prettyprints Actual and Expected values', () => {
+  it('diffs Actual and Expected values', () => {
     const err = throws(() => deepEqual({ b: 2, a: 1 }, { b: 3, a: 1 }));
-    match(/"a": 1,\n {2}"b": 2\n[^]+"a": 1,\n {2}"b": 3\n/, err.message);
+    match(/"a": 1,\n.+- {3}"b": 3.+\n.+\+ {3}"b": 2/, err.message);
   });
 });
 


### PR DESCRIPTION
I'd like a prettier diff like the one from json-diff,
but its array handling is fatally broken at the moment

See: https://github.com/andreyvit/json-diff/issues/18