### PR TITLE
fix: add class contructor execution support to throws()

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ assert.match(explanation, regexp, needle);
 // fail unless the provided functionThatThrows() calls throw
 // (on non-failures the return value is whatever was thrown)
 const err = assert.throws(functionThatThrows);
+const err = assert.throws(ClassThatThrowsInConstructor);
 const err = assert.throws(explanation, functionThatThrows);
 
 // Assertion failed: ensure that bad inputs throw an error

--- a/lib/assertive.js
+++ b/lib/assertive.js
@@ -396,11 +396,15 @@ var assertSync = {
       explanation = undefined;
     }
     if (typeof fn !== 'function') {
-      throw error(name + ' expects ' + green('a function') + ' but got ' + red(fn));
+      throw error(name + ' expects ' + green('a function (or class)') + ' but got ' + red(fn));
     }
 
     try {
-      fn();
+      if(/^\s*class\s+/.test(fn.toString())) {
+        new fn();
+      } else {
+        fn();
+      }
     } catch (err) {
       if (negated) {
         throw error('Threw an exception despite ' + name + ' assertion:\n' + ('' + err.message), explanation);

--- a/test/assertive.test.js
+++ b/test/assertive.test.js
@@ -60,6 +60,17 @@ describe('throws', () => {
     );
   });
 
+  it('will execute a class constructor', () => {
+    const exception = new Error(68087);
+    class SomeClass {
+      constructor() {
+        //execute me
+        throw exception;
+      }
+    }
+    equal(exception, throws(SomeClass));
+  });
+
   it('includes your helpful explanation, when provided', () => {
     const explanation = 'No error was thrown - this is a problem';
     const err = throws(() => throws(explanation, () => {}));


### PR DESCRIPTION
Previously the messaging was: 
```
TypeError: Class constructor SomeClass cannot be invoked without 'new'
```